### PR TITLE
Allow user to specify target directory on blob storage container

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ SyncBlob
 
 Sync files to and from azure blob storage. Usage:
 
-`SyncBlob.exe --direction (ToBlobStorage|FromBlobStorage) --diskLocation <localpath> --containerName <blobstorage container name> --storageConnectionString <storage connection string>`
+`SyncBlob.exe --direction (ToBlobStorage|FromBlobStorage) --diskLocation <localpath> --containerName <blobstorage container name> --storageConnectionString <storage connection string> [--blobDestinationPath <relative blob path>]`
+
+ * `blobDestinationPath` can optionally be used to indicate a target directory where the files will be synced to when `direction` is set to `ToBlobStorage`

--- a/SyncBlob/SyncBlobOptions.cs
+++ b/SyncBlob/SyncBlobOptions.cs
@@ -13,6 +13,8 @@ namespace SyncBlob {
 		public string ContainerName{get;set;}
 		[Option("diskLocation", Required=true)]
 		public string OnDiskPath{get;set;}
+		[Option("blobDestinationPath", HelpText="Optional parameter indicating a destination path to sync files to (only applicable when direction=ToBlobStorage)", Required = false)]
+		public string BlobDestinationPath { get; set; }
 
 		[Option("direction", HelpText="ToBlobStorage or FromBlobStorage", Required=true)]
 		public DirectionEnum Direction{get;set;}

--- a/SyncBlob/ToBlobStorageSyncStrategy.cs
+++ b/SyncBlob/ToBlobStorageSyncStrategy.cs
@@ -6,12 +6,20 @@ using System.Text;
 namespace SyncBlob {
 	class ToBlobStorageSyncStrategy : SyncStrategy{
 		public void Sync(SyncBlobOptions options) {
+			var isAlternativeDestinationPathProvided = !String.IsNullOrEmpty(options.BlobDestinationPath);
+
+			var destinationPath = options.OnDiskPath;
+			if (isAlternativeDestinationPathProvided)
+			{
+				destinationPath = options.BlobDestinationPath;
+			}
+
 			DirectoryHelper.AssertDirectoryAvailable(options.OnDiskPath);
 
 			var localFiles = Files.EnumerateLocalFiles(options.OnDiskPath);
 			var remoteFiles = Blobs.EnumerateBlobs(options.BlobStorageAccountConnectionsString,options.ContainerName);
 
-			remoteFiles.SyncNotAvailable(localFiles);
+			remoteFiles.SyncNotAvailable(localFiles, destinationPath);
 		}
 	}
 }


### PR DESCRIPTION
This PR adds an option which allows the user to specify a destination directory on the blob storage container to which files will be synced.

It's an optional parameter which can only be used when `destination` is set to `ToBlobStorage`
